### PR TITLE
Fixes To The Subcollection Process

### DIFF
--- a/export.js
+++ b/export.js
@@ -44,10 +44,10 @@ results.then(dt => {
 async function getSubCollection(dt){
   for (let [key, value] of Object.entries([dt[collectionName]][0])){
     if(subCollection !== undefined){
-      data[collectionName][key]['subCollection'] = {};
-      await addSubCollection(key, data[collectionName][key]['subCollection']);            
-    }          
-  }  
+      data[collectionName][key][`${subCollection}`] = {};
+      await addSubCollection(key, data[collectionName][key][`${subCollection}`]);
+    }
+  }
 }
 
 function addSubCollection(key, subData){

--- a/export.js
+++ b/export.js
@@ -54,6 +54,11 @@ function addSubCollection(key, subData){
   return new Promise(resolve => {
     db.collection(collectionName).doc(key).collection(subCollection).get()
     .then(snapshot => {      
+
+      if (snapshot.empty) {
+        resolve('Empty')
+      }
+
       snapshot.forEach(subDoc => {             
         subData[subDoc.id] =  subDoc.data();
         resolve('Added data');                                                                 


### PR DESCRIPTION
In trying to get the subcollection, if the subcollection was empty for any one document, the whole process ended.
Resolving when a snapshot is empty solved this.

Making the name of object, the same as the subcollection, gave more information when going through the exported file